### PR TITLE
If the table does not yet exist, return the default.

### DIFF
--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -1,5 +1,5 @@
 class Configurable < ActiveRecord::Base
-  
+
   def self.defaults
     HashWithIndifferentAccess.new(
       YAML.load_file(
@@ -7,12 +7,14 @@ class Configurable < ActiveRecord::Base
       )
     )
   end
-  
+
   def self.keys
     self.defaults.collect { |k,v| k.to_s }.sort
   end
-  
+
   def self.[](key)
+    return self.defaults[key][:default] unless table_exists?
+
     value = find_by_name(key).try(:value) || self.defaults[key][:default]
     case self.defaults[key][:type]
     when 'boolean'
@@ -28,7 +30,7 @@ class Configurable < ActiveRecord::Base
       value
     end
   end
-  
+
   def self.method_missing(name, *args)
     name_stripped = name.to_s.gsub('?', '')
     if self.keys.include?(name_stripped)
@@ -37,5 +39,5 @@ class Configurable < ActiveRecord::Base
       super
     end
   end
-  
+
 end


### PR DESCRIPTION
Since you're fixing my code, here's a patch in kind ;)

This uses the default value if the configurables table doesn't exist - particularly handy when using Configurable within initializers (as per most HyperTiny projects), otherwise you can't run migrations from scratch.
