### PR TITLE
Ensure that 'dev' and 'test' sqlite databases live in different files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ The tests for this rails engine are in the `spec` and `features` directories.  T
 From the top level run:
 
 ```bash
-$ bundle exec rake app:db:schema:load app:db:test:prepare
+$ bundle exec rake app:db:schema:load
+$ bundle exec rake app:db:test:prepare
 $ bundle exec rake
 ```
 

--- a/spec/database/database_sanity_spec.rb
+++ b/spec/database/database_sanity_spec.rb
@@ -1,0 +1,11 @@
+describe 'dummy app database configuration' do
+  it 'ensures that the development and test databases are in different locations' do
+    configs = ActiveRecord::Base.configurations
+    dev_db = configs['development']['database']
+    test_db = configs['test']['database']
+
+    dev_db.should =~ /development/
+    test_db.should =~ /test/
+    dev_db.should_not == test_db
+  end
+end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,19 +1,23 @@
 # config/database.travis.yml
+
+<%
+def db_name(env)
+  (ENV['DB'] || 'sqlite') == 'sqlite' ? "db/#{env}.sqlite3" : "strano_#{env}"
+end
+%>
+
 sqlite: &sqlite
   adapter: sqlite3
-  database: db/<%= Rails.env %>.sqlite3
 
 mysql: &mysql
   adapter: mysql2
   username: root
   password:
-  database: strano_<%= Rails.env %>
 
 postgresql: &postgresql
   adapter: postgresql
   username: postgres
   password:
-  database: strano_<%= Rails.env %>
   min_messages: ERROR
 
 defaults: &defaults
@@ -23,7 +27,9 @@ defaults: &defaults
   <<: *<%= ENV['DB'] || "sqlite" %>
 
 development:
+  database: <%= db_name(:development) %>
   <<: *defaults
 
 test:
+  database: <%= db_name(:test) %>
   <<: *defaults


### PR DESCRIPTION
Previously, when running a rake task, the database.yml would
be generated such that both 'dev' and 'test' databases used
the same file, like db/development.sqlite3. This prevented
tasks that crossed RAILS_ENV boundaries, like app:db:test:prepare,
from correctly finding the test database.

Additionally, running db:schema:load and db:test:prepare in the
same 'rake' seemed to not actually load the schema, so i've
split them up in the README.

Fixes #22 
