### PR TITLE
Fix config reader bug that overrode false values if default was set to true

### DIFF
--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -32,15 +32,17 @@ class Configurable < ActiveRecord::Base
   def self.[](key)
     return parse_value key, defaults[key][:default] unless table_exists?
 
-    val = if ConfigurableEngine::Engine.config.use_cache
+    config = if ConfigurableEngine::Engine.config.use_cache
       Rails.cache.fetch("configurable_engine:#{key}") {
-        find_by_name(key).try(:value)
+        find_by_name(key)
       }
     else
-      find_by_name(key).try(:value)
+      find_by_name(key)
     end
 
-    val ||= parse_value key, defaults[key][:default]
+    return parse_value key, defaults[key][:default] unless config
+
+    config.value
   end
 
   def value

--- a/spec/dummy/config/configurable.yml
+++ b/spec/dummy/config/configurable.yml
@@ -8,6 +8,11 @@ log_out_sso:
   type: boolean
   default: no
 
+accept_applications:
+  name: Accepting Application
+  type: boolean
+  default: true
+
 conversion_rate:
   name: Conversion Rate
   type: decimal

--- a/spec/models/configurable_spec.rb
+++ b/spec/models/configurable_spec.rb
@@ -15,7 +15,8 @@ describe Configurable do
 
   describe ".keys" do
     it "should collect the keys" do
-      Configurable.keys.should == ['conversion_rate',
+      Configurable.keys.should == ['accept_applications',
+                                   'conversion_rate',
                                    'important_number',
                                    'log_out_sso',
                                    'long_list',
@@ -73,6 +74,17 @@ describe Configurable do
       it "should typecast the new value" do
         Configurable[:log_out_sso].should == true
         Configurable.log_out_sso?.should == true
+      end
+    end
+
+    context "with a default boolean of true and a configuration set to false" do
+      before do
+        Configurable.create!(:name => 'accept_applications', :value => false)
+      end
+
+      it "should typecast the new value" do
+        Configurable[:accept_applications].should == false
+        Configurable.accept_applications.should == false
       end
     end
 


### PR DESCRIPTION
Fixes #20

Since we have a value that is literally `false`, the `||=` on line 43 was all "Okay, you don't exist, going on to the default value, then!" which meant that Double Union applications would be perpetually open with this bug, which would be just untenable.

:pineapple: :boom: :pineapple: 
