### PR TITLE
Not Ready for Merge: Allow routes to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### HEAD
 **new features**
-Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/x, thanks @smithev)
+Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/25, thanks @smithev)
 
 ### v0.4.7 - November 4, 2014
 **bug fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### HEAD
+**new features**
+Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/x, thanks @smithev)
+
 ### v0.4.7 - November 4, 2014
 **bug fix**
 Configurable broke for users using cacheing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/25, @smithev).
 * Internal routes can be overriden if the above option is used (https://github.com/paulca/configurable_engine/pull/25, @smithev).
 * Moved the `use_cache` option into the new initializer file (https://github.com/paulca/configurable_engine/pull/25, @smithev).
+* Added strong parameters support for Rails > 4.0 and `attr_accessible` support for Rails < 4.0 (https://github.com/paulca/configurable_engine/pull/25, @smithev)
 
 ### v0.4.7 - November 4, 2014
 **bug fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### HEAD
 **new features**
-Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/25, thanks @smithev)
+* Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/25, @smithev).
+* Internal routes can be overriden if the above option is used (https://github.com/paulca/configurable_engine/pull/25, @smithev).
 
 ### v0.4.7 - November 4, 2014
 **bug fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 **new features**
 * Route generation can be turned off if there is a need to customise them (https://github.com/paulca/configurable_engine/pull/25, @smithev).
 * Internal routes can be overriden if the above option is used (https://github.com/paulca/configurable_engine/pull/25, @smithev).
+* Moved the `use_cache` option into the new initializer file (https://github.com/paulca/configurable_engine/pull/25, @smithev).
 
 ### v0.4.7 - November 4, 2014
 **bug fix**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ Then run the `configurable_engine:install` generator:
 $ rails generate configurable_engine:install
 ```
 
+## Configuration ##
+
+The install generator creates an initializer at `config/initializers/configurable_engine.rb`.
+
+```ruby
+ConfigurableEngine.configure do |config|
+  # have Configurable Engine add routes automatically
+  # config.generate_routes = true
+
+  # override default routing
+  # config.custom_route = -> { Rails.application.routes.url_helpers.admin_configurable_path }
+end
+```
+
+To stop routes from being generated set `config.generate_routes = false`
+
+If you turn off route generation, set the route you want Configurable Engine to use internally instead with `config.custom_route = -> { Rails.application.routes.url_helpers.YOUR_ROUTE_HERE }`
+
 ## Usage ##
 
 There are two parts to how configurable_engine works. First of all there is a config file, config/configurable.yml. This file controls the variables that are allowed to be set in the app.
@@ -99,17 +117,6 @@ Price:
   default: "10.00"          # sets the default value
   type: decimal             # coerces the value to a decimal
 ```
-
-## Configuration ##
-
-```ruby
-ConfigurableEngine.configure do |config|
-  # have Configurable Engine add routes automatically
-  # config.generate_routes = true
-end
-```
-
-If you need to turn off route generation edit the configuration file at `config/initializers/configurable_engine.rb` in your project, and set `config.generate_routes = false`
 
 ## Cacheing ##
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ Price:
   type: decimal             # coerces the value to a decimal
 ```
 
+## Configuration ##
+
+```ruby
+ConfigurableEngine.configure do |config|
+  # have Configurable Engine add routes automatically
+  # config.generate_routes = true
+end
+```
+
+If you need to turn off route generation edit the configuration file at `config/initializers/configurable_engine.rb` in your project, and set `config.generate_routes = false`
+
 ## Cacheing ##
 
 If you want to use rails caching of Configurable updates, simply set

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The install generator creates an initializer at `config/initializers/configurabl
 
 ```ruby
 ConfigurableEngine.configure do |config|
+  # cache config values?
+  # config.use_cache = false
+
   # have Configurable Engine add routes automatically
   # config.generate_routes = true
 
@@ -39,6 +42,8 @@ end
 To stop routes from being generated set `config.generate_routes = false`
 
 If you turn off route generation, set the route you want Configurable Engine to use internally instead with `config.custom_route = -> { Rails.application.routes.url_helpers.YOUR_ROUTE_HERE }`
+
+If you want to use Rails caching of Configurable updates, simply set `config.use_cache = true`
 
 ## Usage ##
 
@@ -117,16 +122,6 @@ Price:
   default: "10.00"          # sets the default value
   type: decimal             # coerces the value to a decimal
 ```
-
-## Cacheing ##
-
-If you want to use rails caching of Configurable updates, simply set
-
-
-```ruby
-config.use_cache = true
-```
-in your `config/application.rb` (or `config/production.rb`)
 
 ## Running the Tests ##
 

--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -1,5 +1,5 @@
 class Configurable < ActiveRecord::Base
-  attr_accessible :name, :value if ConfigurableEngine.active_record_protected_attributes?
+  attr_accessible :name, :value if ConfigurableEngine.protected_attributes?
 
   after_save    :invalidate_cache, if: -> { ConfigurableEngine.use_cache }
   after_destroy :invalidate_cache, if: -> { ConfigurableEngine.use_cache }

--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -1,6 +1,6 @@
 class Configurable < ActiveRecord::Base
-  after_save    :invalidate_cache, if: -> { ConfigurableEngine::Engine.config.use_cache }
-  after_destroy :invalidate_cache, if: -> { ConfigurableEngine::Engine.config.use_cache }
+  after_save    :invalidate_cache, if: -> { ConfigurableEngine.use_cache }
+  after_destroy :invalidate_cache, if: -> { ConfigurableEngine.use_cache }
 
   validates_presence_of    :name
   validates_uniqueness_of  :name
@@ -44,7 +44,7 @@ class Configurable < ActiveRecord::Base
     end
 
 
-    if ConfigurableEngine::Engine.config.use_cache
+    if ConfigurableEngine.use_cache
       found = Rails.cache.exist?(cache_key(key))
       if found
         value = Rails.cache.fetch(cache_key(key))

--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -1,4 +1,6 @@
 class Configurable < ActiveRecord::Base
+  attr_accessible :name, :value if ConfigurableEngine.active_record_protected_attributes?
+
   after_save    :invalidate_cache, if: -> { ConfigurableEngine.use_cache }
   after_destroy :invalidate_cache, if: -> { ConfigurableEngine.use_cache }
 

--- a/app/views/admin/configurables/show.html.erb
+++ b/app/views/admin/configurables/show.html.erb
@@ -1,6 +1,6 @@
 <h2>Config</h2>
 
-<%= form_tag(admin_configurable_path, :method => :put) do -%>
+<%= form_tag(ConfigurableEngine.custom_route, :method => :put) do -%>
   <%- @keys.each do |key| -%>
     <%- options = Configurable.defaults[key] -%>
     <div class="configurable">
@@ -19,6 +19,6 @@
       <%- end -%>
     </div>
   <%- end -%>
-  
+
   <%= submit_tag 'Save' %>
 <%- end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
-Rails.application.routes.draw do
-  namespace :admin do
-    resource :configurable
+if ConfigurableEngine.generate_routes
+  Rails.application.routes.draw do
+    namespace :admin do
+      resource :configurable
+    end
   end
 end

--- a/configurable_engine.gemspec
+++ b/configurable_engine.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     "README.md"
   ]
 
-  spec.files         = Dir["*.txt", "*.md", "lib/**/*", "app/**/*", "config/**/*"] - ['config/cucumber.yml'] 
+  spec.files         = Dir["*.txt", "*.md", "lib/**/*", "app/**/*", "config/**/*"] - ['config/cucumber.yml']
   #re-enable test files when they're actually used.  In the mean time, lets leave them out to reduce our gem size.
   #spec.test_files    = Dir['features/**/*', 'spec/**/*', 'gemfiles/**/*'] + %w{config/cucumber.yml .rspec tasks/cucumber.rake}
 
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.rubygems_version = "2.0.3"
   spec.summary = "Database-backed configuration for Rails 3, with defaults from config file."
 
-  spec.add_dependency "rails", ">3.1.0"
+  spec.add_dependency 'rails', '>= 3.1.0', '< 5.0'
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -11,7 +11,7 @@ module NavigationHelpers
     when /the home\s?page/
       '/'
     when /the config admin page/
-      admin_configurable_path
+      ConfigurableEngine.custom_route
 
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:

--- a/lib/configurable_engine.rb
+++ b/lib/configurable_engine.rb
@@ -1,2 +1,16 @@
 require 'configurable_engine/engine'
 require 'configurable_engine/configurables_controller'
+
+module ConfigurableEngine
+  mattr_accessor :generate_routes
+
+  def self.configure
+    yield self
+  end
+
+  def self.reset_config
+    self.generate_routes = true
+  end
+
+  reset_config
+end

--- a/lib/configurable_engine.rb
+++ b/lib/configurable_engine.rb
@@ -2,7 +2,7 @@ require 'configurable_engine/engine'
 require 'configurable_engine/configurables_controller'
 
 module ConfigurableEngine
-  mattr_accessor :generate_routes
+  mattr_accessor :custom_route, :generate_routes
 
   def self.configure
     yield self
@@ -10,6 +10,7 @@ module ConfigurableEngine
 
   def self.reset_config
     self.generate_routes = true
+    self.custom_route    = -> { admin_configurable_path }
   end
 
   reset_config

--- a/lib/configurable_engine.rb
+++ b/lib/configurable_engine.rb
@@ -2,13 +2,14 @@ require 'configurable_engine/engine'
 require 'configurable_engine/configurables_controller'
 
 module ConfigurableEngine
-  mattr_accessor :custom_route, :generate_routes
+  mattr_accessor :custom_route, :generate_routes, :use_cache
 
   def self.configure
     yield self
   end
 
   def self.reset_config
+    self.use_cache       = false
     self.generate_routes = true
     self.custom_route    = -> { admin_configurable_path }
   end

--- a/lib/configurable_engine.rb
+++ b/lib/configurable_engine.rb
@@ -14,5 +14,9 @@ module ConfigurableEngine
     self.custom_route    = -> { admin_configurable_path }
   end
 
+  def self.active_record_protected_attributes?
+    @active_record_protected_attributes ||= ::ActiveRecord::VERSION::MAJOR < 4 || !!defined?(ProtectedAttributes)
+  end
+
   reset_config
 end

--- a/lib/configurable_engine.rb
+++ b/lib/configurable_engine.rb
@@ -14,7 +14,7 @@ module ConfigurableEngine
     self.custom_route    = -> { admin_configurable_path }
   end
 
-  def self.active_record_protected_attributes?
+  def self.protected_attributes?
     @active_record_protected_attributes ||= ::ActiveRecord::VERSION::MAJOR < 4 || !!defined?(ProtectedAttributes)
   end
 

--- a/lib/configurable_engine/configurables_controller.rb
+++ b/lib/configurable_engine/configurables_controller.rb
@@ -15,10 +15,11 @@ module ConfigurableEngine
         end
 
       if failures.empty?
-        redirect_to admin_configurable_path, :notice => "Changes successfully updated"
+        redirect_to ConfigurableEngine.custom_route, notice: "Changes successfully updated"
       else
         flash[:error] = failures.flat_map(&:errors).flat_map(&:full_messages).join(',')
-        redirect_to admin_configurable_path
+
+        redirect_to ConfigurableEngine.custom_route
       end
     end
   end

--- a/lib/configurable_engine/configurables_controller.rb
+++ b/lib/configurable_engine/configurables_controller.rb
@@ -5,12 +5,11 @@ module ConfigurableEngine
     end
 
     def update
-      failures = Configurable
-        .keys.map do |key|
+      failures = Configurable.keys.map do |key|
           Configurable.find_by_name(key) ||
-            Configurable.create {|c| c.name = key}
+            Configurable.create { |c| c.name = key }
         end.reject do |configurable|
-          configurable.value = params[configurable.name]
+          configurable.value = configurable_params[configurable.name]
           configurable.save
         end
 
@@ -20,6 +19,18 @@ module ConfigurableEngine
         flash[:error] = failures.flat_map(&:errors).flat_map(&:full_messages).join(',')
 
         redirect_to ConfigurableEngine.custom_route
+      end
+    end
+
+    def configurable_params
+      if ConfigurableEngine.active_record_protected_attributes?
+        params
+      else
+        params.require(:configurable).tap do |whitelisted|
+          Configurable.keys.map(&:to_sym).each do |key|
+            whitelisted[key] = params[:configurable][key]
+          end
+        end
       end
     end
   end

--- a/lib/configurable_engine/configurables_controller.rb
+++ b/lib/configurable_engine/configurables_controller.rb
@@ -6,15 +6,15 @@ module ConfigurableEngine
 
     def update
       failures = Configurable.keys.map do |key|
-          Configurable.find_by_name(key) ||
-            Configurable.create { |c| c.name = key }
-        end.reject do |configurable|
-          configurable.value = configurable_params[configurable.name]
-          configurable.save
-        end
+        Configurable.find_by_name(key) || Configurable.create { |c| c.name = key }
+      end.reject do |configurable|
+        configurable.value = configurable_params[configurable.name]
+
+        configurable.save
+      end
 
       if failures.empty?
-        redirect_to ConfigurableEngine.custom_route, notice: "Changes successfully updated"
+        redirect_to ConfigurableEngine.custom_route, notice: 'Changes successfully updated'
       else
         flash[:error] = failures.flat_map(&:errors).flat_map(&:full_messages).join(',')
 
@@ -23,8 +23,8 @@ module ConfigurableEngine
     end
 
     def configurable_params
-      if ConfigurableEngine.active_record_protected_attributes?
-        params
+      if ConfigurableEngine.protected_attributes?
+        params[:configurable]
       else
         params.require(:configurable).tap do |whitelisted|
           Configurable.keys.map(&:to_sym).each do |key|

--- a/lib/configurable_engine/engine.rb
+++ b/lib/configurable_engine/engine.rb
@@ -1,6 +1,5 @@
 module ConfigurableEngine
   class Engine < Rails::Engine
-    config.use_cache = false
     config.generators do |g|
       g.test_framework :rspec
     end

--- a/lib/configurable_engine/version.rb
+++ b/lib/configurable_engine/version.rb
@@ -1,3 +1,3 @@
 module ConfigurableEngine
-  VERSION = '0.4.7'
+  VERSION = '0.4.8'
 end

--- a/lib/generators/configurable_engine/install_generator.rb
+++ b/lib/generators/configurable_engine/install_generator.rb
@@ -1,24 +1,25 @@
 require 'rails/generators'
+
 module ConfigurableEngine
-class InstallGenerator < Rails::Generators::Base
-  include Rails::Generators::Migration
+  class InstallGenerator < Rails::Generators::Base
+    include Rails::Generators::Migration
 
-
-   def self.source_root
+    def self.source_root
       @source_root ||= File.join(File.dirname(__FILE__), 'templates')
-   end
- 
-   def self.next_migration_number(dirname)
+    end
+
+    def self.next_migration_number(dirname)
       if ActiveRecord::Base.timestamped_migrations
         Time.now.utc.strftime("%Y%m%d%H%M%S")
       else
         "%.3d" % (current_migration_number(dirname) + 1)
       end
     end
- 
+
     def create_migration_file
       copy_file 'configurable.yml', 'config/configurable.yml'
       migration_template 'migration.rb', 'db/migrate/create_configurables.rb'
+      copy_file 'configurable_engine.rb', 'config/initializers/configurable_engine.rb'
     end
   end
 end

--- a/lib/generators/configurable_engine/templates/configurable_engine.rb
+++ b/lib/generators/configurable_engine/templates/configurable_engine.rb
@@ -1,4 +1,7 @@
 ConfigurableEngine.configure do |config|
   # have Configurable Engine add routes automatically
   # config.generate_routes = true
+
+  # override default routing
+  # config.custom_route = -> { Rails.application.routes.url_helpers.admin_configurable_path }
 end

--- a/lib/generators/configurable_engine/templates/configurable_engine.rb
+++ b/lib/generators/configurable_engine/templates/configurable_engine.rb
@@ -1,4 +1,7 @@
 ConfigurableEngine.configure do |config|
+  # cache config values?
+  # config.use_cache = false
+
   # have Configurable Engine add routes automatically
   # config.generate_routes = true
 

--- a/lib/generators/configurable_engine/templates/configurable_engine.rb
+++ b/lib/generators/configurable_engine/templates/configurable_engine.rb
@@ -1,0 +1,4 @@
+ConfigurableEngine.configure do |config|
+  # have Configurable Engine add routes automatically
+  # config.generate_routes = true
+end


### PR DESCRIPTION
We use a heavily namespaced application consisting of many different engines and needed a way to customise the routes without leaving the default ones hanging around.

This PR adds a simple configuration utility and initializer file. This is my first PR so hopefully everything is OK for you.
