### PR TITLE
Use proper method of Rails.cache for writing

### DIFF
--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -51,7 +51,7 @@ class Configurable < ActiveRecord::Base
       else
         database_finder.call
         if found
-          Rails.cache.store cache_key(key), value
+          Rails.cache.write cache_key(key), value
         end
       end
     else


### PR DESCRIPTION
It seems that Rails.cache doesn't have method #store at all.