### PR TITLE
I18n support and form classes for scss styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,38 @@ Price:
 
 If you want to use rails caching of Configurable updates, simply set
 
+## Translating the interface ##
+
+### Labels ###
+
+If you want labels in your admin interface to be translated, just set a `i18n_key` option for your configuration:
+
+```
+Price:
+  name: A price                # sets the edit label
+  default: "10.00"             # sets the default value
+  type: decimal                # coerces the value to a decimal
+  i18n_key: configurable.price # this will call I18n.t('configurable.price') to display the label
+```
+
+In this case the `name` label won't be used in the admin interface.
+
+### Title ###
+
+You can translate the title of the page by setting a translation for the key `configurable.admin_title`:
+
+```
+# example config/locales/en.yml
+...
+configurable:
+  admin_title: My cool app configuration
+...
+```
+
+### Submit button ###
+
+Same as title, but the key is `configurable.submit_button`.
+
 
 ```ruby
 config.use_cache = true

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Price:
 
 If you want to use rails caching of Configurable updates, simply set
 
+```ruby
+config.use_cache = true
+```
+
+in your `config/application.rb` (or `config/production.rb`)
+
 ## Translating the interface ##
 
 ### Labels ###
@@ -137,10 +143,40 @@ configurable:
 Same as title, but the key is `configurable.submit_button`.
 
 
-```ruby
-config.use_cache = true
+## Styling the interface ##
+
+To style the web interface you are advised to use Sass. Here's an example scss file that will make the interface bootstrap-3 ready:
+
 ```
-in your `config/application.rb` (or `config/production.rb`)
+@import 'bootstrap';
+
+.configurable-container {
+  @extend .col-md-6;
+
+  .configurable-options {
+    form {
+      @extend .form-horizontal;
+
+      .configurable {
+        @extend .col-md-12;
+        @extend .form-group;
+
+        textarea, input[type=text], input[type=password] {
+          @extend .form-control;
+        }
+      }
+
+      input[type=submit] {
+        @extend .btn;
+        @extend .btn-primary;
+      }
+    }
+  }
+}
+
+```
+
+Just save this into your rails assets and you're ready to go.
 
 ## Running the Tests ##
 

--- a/app/views/admin/configurables/show.html.erb
+++ b/app/views/admin/configurables/show.html.erb
@@ -1,24 +1,35 @@
-<h2>Config</h2>
+<div class='configurable-container'>
 
-<%= form_tag(admin_configurable_path, :method => :put) do -%>
-  <%- @keys.each do |key| -%>
-    <%- options = Configurable.defaults[key] -%>
-    <div class="configurable">
-      <%= label_tag key, options[:name] %>
-      <%- if options[:type] == 'boolean' %>
-        <%= hidden_field_tag key, "0" %>
-        <%= check_box_tag key, "1", Configurable.send(key) %>
-      <%- elsif options[:type] == 'password' -%>
-        <%= password_field_tag key, Configurable.send(key) %>
-      <%- elsif options[:type] == 'text' -%>
-        <%= text_area_tag key, Configurable.send(key) %>
-      <%- elsif options[:type] == 'list' -%>
-        <%= text_area_tag key, Configurable.serialized_value(key) -%>
-      <%- else -%>
-        <%= text_field_tag key, Configurable.send(key) %>
+  <div class="header">
+    <h2><%= t('configurable.admin_title', default: "Config") %></h2>
+  </div>
+
+  <div class="configurable-options">
+    <%= form_tag(admin_configurable_path, :method => :put) do -%>
+      <%- @keys.each do |key| -%>
+        <%- options = Configurable.defaults[key] -%>
+        <div class="configurable">
+          <% if options[:i18n_key] %>
+            <%= label_tag key, t(options[:i18n_key]) %>
+          <% else %>
+            <%= label_tag key, options[:name] %>
+          <% end %>
+          <%- if options[:type] == 'boolean' %>
+            <%= hidden_field_tag key, "0" %>
+            <%= check_box_tag key, "1", Configurable.send(key) %>
+          <%- elsif options[:type] == 'password' -%>
+            <%= password_field_tag key, Configurable.send(key) %>
+          <%- elsif options[:type] == 'text' -%>
+            <%= text_area_tag key, Configurable.send(key) %>
+          <%- elsif options[:type] == 'list' -%>
+            <%= text_area_tag key, Configurable.serialized_value(key) -%>
+          <%- else -%>
+            <%= text_field_tag key, Configurable.send(key) %>
+          <%- end -%>
+        </div>
       <%- end -%>
-    </div>
-  <%- end -%>
-  
-  <%= submit_tag 'Save' %>
-<%- end -%>
+
+      <%= submit_tag t('configurable.submit_button', default: 'Save') %>
+    <%- end -%>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds two things:

* support for internationalization of both labels and admin interface elements
* some convenience classes to allow targeting form elements via scss.

See the README file to see how it works.

This PR can be applied without any changes for the current users experience.