### PR TITLE
add date type

### DIFF
--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -85,6 +85,8 @@ class Configurable < ActiveRecord::Base
       else
         value.split("\n").collect { |v| v =~ /,/ ? v.split(',') : v }
       end
+    when 'date'
+      Date.parse(value) if value.present?
     else
       value
     end
@@ -131,6 +133,8 @@ class Configurable < ActiveRecord::Base
       Integer(value) rescue false
     when 'list'
       value.is_a?(Array)
+    when 'date'
+      value.is_a?(Date)
     else
       true
     end

--- a/spec/dummy/config/configurable.yml
+++ b/spec/dummy/config/configurable.yml
@@ -30,3 +30,8 @@ long_list:
     - [ One, 1 ]
     - [ Two, 2 ]
     - [ Three, 3 ]
+
+important_date:
+  name: Important Date
+  type: date
+  default: '2015-05-14'

--- a/spec/models/configurable_spec.rb
+++ b/spec/models/configurable_spec.rb
@@ -17,6 +17,7 @@ describe Configurable do
     it "should collect the keys" do
       Configurable.keys.should == ['accept_applications',
                                    'conversion_rate',
+                                   'important_date',
                                    'important_number',
                                    'log_out_sso',
                                    'long_list',
@@ -105,6 +106,16 @@ describe Configurable do
 
       it "should typecast the value" do
         Configurable.important_number.should == 100
+      end
+    end
+
+    context "with a date value" do
+      before do
+        Configurable.create!(:name => 'important_date', :value => '2016-11-23')
+      end
+
+      it "should typecast the value" do
+        Configurable.important_date.should == Date.parse('2016-11-23')
       end
     end
 


### PR DESCRIPTION
When you set an attribute type as date in configurable.yml, configurable_engine parses the predefined value correctly. But when you update the attribute, configurable_engine obtains the value from db as a string value and doesn't parse it. So you need to check the value type in a business logic. 

In this PR I have fixed it and added date type.