### PR TITLE
Cache default values

### DIFF
--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -61,7 +61,11 @@ class Configurable < ActiveRecord::Base
     if found
       value
     else
-      parse_value key, defaults[key][:default]
+      parse_value(key, defaults[key][:default]).tap do |val|
+        if ConfigurableEngine::Engine.config.use_cache
+          Rails.cache.write cache_key(key), val
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Previously, if caching was turned on but a key was not yet in the persisted database,
the engine returned the default value without caching it.  Therefore, the next time
the key was requested, the engine attempted once more to find the value with a database call.

This commit makes the engine cache the default value so that the engine does not continue
to query the database every time the value is requested.

The test suite passes, but I did not add any new tests, since caching was not previously being tested.