### PR TITLE
Add configurable name to the error

### DIFF
--- a/lib/configurable_engine/configurables_controller_methods.rb
+++ b/lib/configurable_engine/configurables_controller_methods.rb
@@ -18,7 +18,11 @@ module ConfigurableEngine
       if failures.empty?
         redirect_to(action: :show, :notice => "Changes successfully updated")
       else
-        flash[:error] = failures.flat_map(&:errors).flat_map(&:full_messages).join(',')
+        flash[:error] = failures.map { |c| [c, c.errors] }.flat_map { |c, e|
+          e.full_messages.map { |m|
+            "#{c.name} #{m.downcase}"
+          }
+        }.join(',')
         redirect_to(action: :show)
       end
     end


### PR DESCRIPTION
When updating a value with an invalid type the flash[:error] message only says "invalid value" (or whatever is stated in `activerecord.errors.messages.invalid` i18n). There is no contextual information for the user regarding which configurable is failing.

This PR addresses that by prefixing the message with the configurable name.

Another alternative would be add a custom i18n friendly error key for this. But I didn't want to introduce more than what was needed.